### PR TITLE
Add Pratt truss analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,26 @@
-# study
+# Study Repository
+
+This repository demonstrates matrix-displacement analysis for simple trusses.
+
+## Files
+- `king_post_analysis.py` — analyzes a king-post roof truss.
+- `pratt_truss_analysis.py` — analyzes a six-panel Pratt through-truss bridge.
+
+## Requirements
+The examples require `numpy` and `matplotlib`.
+Install them using:
+
+```bash
+pip install -r requirements.txt
+```
+
+## Usage
+Run either analysis script with Python 3:
+
+```bash
+python3 king_post_analysis.py
+python3 pratt_truss_analysis.py
+```
+
+Each program prints joint displacements, support reactions and axial forces and
+shows a plot comparing undeformed and deformed shapes.

--- a/king_post_analysis.py
+++ b/king_post_analysis.py
@@ -1,0 +1,115 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+def element_stiffness(E, A, node_i, node_j):
+    xi, yi = node_i
+    xj, yj = node_j
+    L = np.hypot(xj - xi, yj - yi)
+    c = (xj - xi) / L
+    s = (yj - yi) / L
+    k = (E * A / L) * np.array([
+        [ c*c,  c*s, -c*c, -c*s],
+        [ c*s,  s*s, -c*s, -s*s],
+        [-c*c, -c*s,  c*c,  c*s],
+        [-c*s, -s*s,  c*s,  s*s],
+    ])
+    return k, L, c, s
+
+nodes = np.array([
+    [0.0, 0.0],  # Node 1
+    [10.0, 0.0], # Node 2
+    [5.0, 0.0],  # Node 3
+    [5.0, 5.0],  # Node 4
+])
+
+members = [
+    (0, 3), # 1-4 left top chord
+    (1, 3), # 2-4 right top chord
+    (0, 2), # 1-3 left bottom chord
+    (2, 1), # 3-2 right bottom chord
+    (2, 3), # 3-4 vertical
+]
+
+E = 2.1e11
+A = 5.0e-3
+P = 10e3 # N
+
+dof_per_node = 2
+n_nodes = len(nodes)
+K = np.zeros((dof_per_node*n_nodes, dof_per_node*n_nodes))
+member_info = []
+for start, end in members:
+    k, L, c, s = element_stiffness(E, A, nodes[start], nodes[end])
+    dofs = [dof_per_node*start, dof_per_node*start+1,
+            dof_per_node*end,   dof_per_node*end+1]
+    for i in range(4):
+        for j in range(4):
+            K[dofs[i], dofs[j]] += k[i, j]
+    member_info.append({'L': L, 'c': c, 's': s, 'dofs': dofs})
+
+F = np.zeros(dof_per_node*n_nodes)
+F[dof_per_node*3+1] = -P  # Joint 4 vertical load
+
+# Boundary conditions: node1 u,v fixed; node2 v fixed
+fixed_dofs = [0, 1, 3]
+free_dofs = [i for i in range(dof_per_node*n_nodes) if i not in fixed_dofs]
+
+K_ff = K[np.ix_(free_dofs, free_dofs)]
+F_f = F[free_dofs]
+
+U = np.zeros(dof_per_node*n_nodes)
+U[free_dofs] = np.linalg.solve(K_ff, F_f)
+
+# Reactions
+R = K @ U - F
+
+# Axial member forces
+axial = []
+for info in member_info:
+    dofs = info['dofs']
+    c = info['c']
+    s = info['s']
+    L = info['L']
+    AeL = E*A/L
+    u_e = U[dofs]
+    force = AeL * np.array([-c, -s, c, s]) @ u_e
+    axial.append(force)
+
+# Print results
+print("Joint displacements (m):")
+for i in range(n_nodes):
+    ux, uy = U[2*i], U[2*i+1]
+    print(f"Node {i+1}: ux={ux:.6e} uy={uy:.6e}")
+
+print("\nSupport reactions (N):")
+labels = ['Fx1','Fy1','Fy2']
+for lab, val in zip(labels, R[fixed_dofs]):
+    print(f"{lab}: {val:.2f}")
+
+print("\nAxial member forces (N):")
+for idx, force in enumerate(axial, 1):
+    print(f"Member {idx}: {force:.2f}")
+
+# Plot undeformed and deformed shapes
+scale = 1000  # arbitrary scaling for visualization
+fig, ax = plt.subplots()
+
+# undeformed
+for start, end in members:
+    x = [nodes[start,0], nodes[end,0]]
+    y = [nodes[start,1], nodes[end,1]]
+    ax.plot(x, y, 'k--', lw=1)
+
+# deformed
+def_nodes = nodes + U.reshape((n_nodes, dof_per_node))*scale
+for start, end in members:
+    x = [def_nodes[start,0], def_nodes[end,0]]
+    y = [def_nodes[start,1], def_nodes[end,1]]
+    ax.plot(x, y, 'r-', lw=2)
+
+ax.set_aspect('equal')
+ax.set_xlabel('x [m]')
+ax.set_ylabel('y [m]')
+ax.set_title('King-Post Truss: Undeformed (black dashed) vs Deformed (red)')
+plt.grid(True)
+plt.show()

--- a/pratt_truss_analysis.py
+++ b/pratt_truss_analysis.py
@@ -1,0 +1,149 @@
+import numpy as np
+import matplotlib.pyplot as plt
+
+
+def element_stiffness(E, A, node_i, node_j):
+    xi, yi = node_i
+    xj, yj = node_j
+    L = np.hypot(xj - xi, yj - yi)
+    c = (xj - xi) / L
+    s = (yj - yi) / L
+    k = (E * A / L) * np.array([
+        [ c*c,  c*s, -c*c, -c*s],
+        [ c*s,  s*s, -c*s, -s*s],
+        [-c*c, -c*s,  c*c,  c*s],
+        [-c*s, -s*s,  c*s,  s*s],
+    ])
+    return k, L, c, s
+
+
+def assemble_global_stiffness(nodes, members, E, A):
+    dof_per_node = 2
+    n_nodes = len(nodes)
+    K = np.zeros((dof_per_node*n_nodes, dof_per_node*n_nodes))
+    member_info = []
+    for start, end in members:
+        k, L, c, s = element_stiffness(E, A, nodes[start], nodes[end])
+        dofs = [dof_per_node*start, dof_per_node*start+1,
+                dof_per_node*end,   dof_per_node*end+1]
+        for i in range(4):
+            for j in range(4):
+                K[dofs[i], dofs[j]] += k[i, j]
+        member_info.append({'L': L, 'c': c, 's': s, 'dofs': dofs})
+    return K, member_info
+
+
+def solve_truss(nodes, members, E, A, loads, fixed_dofs):
+    dof_per_node = 2
+    n_nodes = len(nodes)
+    K, member_info = assemble_global_stiffness(nodes, members, E, A)
+    free_dofs = [i for i in range(dof_per_node*n_nodes) if i not in fixed_dofs]
+
+    K_ff = K[np.ix_(free_dofs, free_dofs)]
+    F_f = loads[free_dofs]
+
+    U = np.zeros(dof_per_node*n_nodes)
+    U[free_dofs] = np.linalg.solve(K_ff, F_f)
+
+    R = K @ U - loads
+
+    axial = []
+    for info in member_info:
+        dofs = info['dofs']
+        c = info['c']
+        s = info['s']
+        L = info['L']
+        AeL = E*A/L
+        u_e = U[dofs]
+        force = AeL * np.array([-c, -s, c, s]) @ u_e
+        axial.append(force)
+
+    return U, R, axial
+
+
+def plot_truss(nodes, members, U, title, scale=50):
+    dof_per_node = 2
+    n_nodes = len(nodes)
+    def_nodes = nodes + U.reshape((n_nodes, dof_per_node))*scale
+
+    fig, ax = plt.subplots()
+    for start, end in members:
+        x = [nodes[start,0], nodes[end,0]]
+        y = [nodes[start,1], nodes[end,1]]
+        ax.plot(x, y, 'k--', lw=1)
+    for start, end in members:
+        x = [def_nodes[start,0], def_nodes[end,0]]
+        y = [def_nodes[start,1], def_nodes[end,1]]
+        ax.plot(x, y, 'r-', lw=2)
+    ax.set_aspect('equal')
+    ax.set_xlabel('x [m]')
+    ax.set_ylabel('y [m]')
+    ax.set_title(title)
+    plt.grid(True)
+    plt.show()
+
+
+if __name__ == "__main__":
+    # Geometry
+    L = 30.0
+    H = 6.0
+    panel = 5.0
+
+    bottom_nodes = [(i*panel, 0.0) for i in range(7)]
+    top_nodes = [(i*panel, H) for i in range(7)]
+    nodes = np.array(bottom_nodes + top_nodes)
+
+    # Members
+    members = []
+    # bottom chord
+    for i in range(6):
+        members.append((i, i+1))
+    # top chord
+    for i in range(7, 13):
+        members.append((i, i+1))
+    # verticals
+    for i in range(7):
+        members.append((i, i+7))
+    # diagonals
+    for i in range(3):
+        members.append((i, i+8))  # left half
+    for i in range(3,6):
+        members.append((i+7, i+1))  # right half
+
+    E = 2.1e11
+    A = 8.0e-3
+    q = 15e3
+
+    dof_per_node = 2
+    n_nodes = len(nodes)
+    loads = np.zeros(dof_per_node*n_nodes)
+    panel_load = q * panel
+    # bottom joints 0..6
+    for i in range(7):
+        load = panel_load
+        if i == 0 or i == 6:
+            load *= 0.5
+        loads[2*i+1] = -load
+
+    fixed_dofs = [0, 1, 2*6 + 1]
+
+    U, R, axial = solve_truss(nodes, members, E, A, loads, fixed_dofs)
+
+    print("Joint displacements (m):")
+    for i in range(n_nodes):
+        ux, uy = U[2*i], U[2*i+1]
+        print(f"Node {i+1}: ux={ux:.6e} uy={uy:.6e}")
+
+    print("\nSupport reactions (N):")
+    labels = ["Fx1","Fy1","Fy7"]
+    for lab, val in zip(labels, R[fixed_dofs]):
+        print(f"{lab}: {val:.2f}")
+
+    print("\nAxial member forces (N):")
+    for idx, force in enumerate(axial, 1):
+        print(f"Member {idx}: {force:.2f}")
+
+    plot_truss(nodes, members, U,
+               "Pratt Through-Truss: Undeformed (black dashed) vs Deformed (red)",
+               scale=200)
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+numpy
+matplotlib


### PR DESCRIPTION
## Summary
- extend README with requirements and usage
- provide new script `pratt_truss_analysis.py` for a six‑panel Pratt through‑truss bridge
- add simple requirements.txt for installing needed Python packages

## Testing
- `python3 king_post_analysis.py` *(fails: ModuleNotFoundError for numpy)*
- `python3 pratt_truss_analysis.py` *(fails: ModuleNotFoundError for numpy)*

------
https://chatgpt.com/codex/tasks/task_e_685ea0d1988c8331b6f387b061e5002f