### PR TITLE
Add Hawthorne truss material data

### DIFF
--- a/assembleK.m
+++ b/assembleK.m
@@ -1,0 +1,19 @@
+function K = assembleK(nodes,elems,E)
+%ASSEMBLEK Assemble global stiffness matrix for a truss.
+%   K = ASSEMBLEK(NODES,ELEMS,E) builds the sparse global stiffness matrix
+%   for the structure defined by NODES and ELEMS using Young's modulus E.
+%   Each element in ELEMS must have fields .i, .j, and .A (area).
+%   Nodes are assumed to have 2 DOF: [ux uy].
+
+n = size(nodes,1);
+ndof = 2*n;
+K = sparse(ndof, ndof);
+
+for e = elems(:)'
+    xi = nodes(e.i,1); yi = nodes(e.i,2);
+    xj = nodes(e.j,1); yj = nodes(e.j,2);
+    Ke = trussKe(xi,yi,xj,yj,E,e.A);
+    dof = [2*e.i-1, 2*e.i, 2*e.j-1, 2*e.j];
+    K(dof,dof) = K(dof,dof) + Ke;
+end
+end

--- a/hawthorne_truss.m
+++ b/hawthorne_truss.m
@@ -1,0 +1,63 @@
+function [nodes, elems, A, E, fy] = hawthorne_truss()
+%HAWTHORNE_TRUSS Node, element, and material data for the Hawthorne through-Pratt truss.
+%   [NODES, ELEMS, A, E, FY] = HAWTHORNE_TRUSS() returns node coordinates,
+%   element connectivity, section areas, Young''s modulus, and yield stress for
+%   the 73.15 m main span of the Hawthorne bridge.
+%   Nodes are ordered with bottom-chord joints first, followed by the top.
+%
+%   NODES - (26x2) array of [x y] coordinates
+%   ELEMS - struct array with fields:
+%           .i    start node index
+%           .j    finish node index
+%           .type 'BOT', 'TOP', 'DIAG', or 'VERT'
+%           .A    cross-sectional area (m^2)
+
+    dx = 73.15 / 12;                 % panel length
+    x = (0:12)' * dx;                % x-coordinates for both chords
+
+    bottom = [x, zeros(13,1)];       % bottom chord nodes
+    top    = [x, 9.14 * ones(13,1)]; % top chord nodes
+    nodes  = [bottom; top];          % combine
+
+    elems = struct('i', {}, 'j', {}, 'type', {});
+
+    % material properties
+    E  = 2.1e11; % Pa
+    fy = struct('TOP', 248e6, 'BOT', 248e6, 'DIAG', 248e6, 'VERT', 248e6);
+
+    % cross-sectional areas (m^2)
+    A = struct('TOP', 0.08, 'BOT', 0.16, 'DIAG', 0.08, 'VERT', 0.10);
+
+    % bottom chord elements
+    for k = 1:12
+        elems(end+1) = struct('i', k, 'j', k+1, 'type', 'BOT', 'A', A.BOT);
+    end
+
+    % top chord elements
+    for k = 14:25
+        elems(end+1) = struct('i', k, 'j', k+1, 'type', 'TOP', 'A', A.TOP);
+    end
+
+    % verticals
+    for k = 1:13
+        elems(end+1) = struct('i', k, 'j', k+13, 'type', 'VERT', 'A', A.VERT);
+    end
+
+    % Pratt diagonals - slope downward toward mid-span
+    for k = 1:6
+        elems(end+1) = struct('i', 13 + k, 'j', k + 1, 'type', 'DIAG', 'A', A.DIAG);
+    end
+    for k = 7:12
+        elems(end+1) = struct('i', 13 + (k + 1), 'j', k, 'type', 'DIAG', 'A', A.DIAG);
+    end
+
+    if nargout == 0
+        disp('First 5 nodes:');
+        disp(nodes(1:5,:));
+        disp('First 5 elements:');
+        for n = 1:5
+            e = elems(n);
+            fprintf('%d %d %s A=%.2f\n', e.i, e.j, e.type, e.A);
+        end
+    end
+end

--- a/makeLoads.m
+++ b/makeLoads.m
@@ -1,0 +1,69 @@
+function F = makeLoads(nodes, elems)
+%MAKELOADS Construct basic load vectors for the Hawthorne truss.
+%   F = MAKELOADS(NODES,ELEMS) returns a struct of load vectors for the
+%   provided node coordinates and element data. The struct contains
+%   fields:
+%      F.DL   - dead load (deck + self weight)
+%      F.LIVE - live + pedestrian load
+%      F.WIND - wind pressure
+%      F.EQ   - equivalent earthquake base shear
+%
+%   Each vector is of size 2*N, where N is the number of nodes, using
+%   the DOF order [ux1 uy1 ux2 uy2 ...].  Forces are in Newtons.
+
+n  = size(nodes,1);
+nd = 2*n;
+F.DL   = zeros(nd,1);
+F.LIVE = zeros(nd,1);
+F.WIND = zeros(nd,1);
+F.EQ   = zeros(nd,1);
+
+%% Dead load: deck weight along the bottom chord
+wDeck = 5e3;                         % N/m
+bottomNodes = 1:13;
+F.DL = addUniform(F.DL, nodes, bottomNodes, [0; -wDeck]);
+
+%% Dead load: self weight of members
+rho = 78.5e3;                        % N/m^3
+for e = elems(:)'
+    i = e.i; j = e.j;
+    L = hypot(nodes(j,1)-nodes(i,1), nodes(j,2)-nodes(i,2));
+    w = rho * e.A * L;               % total weight
+    F.DL(2*i) = F.DL(2*i) - w/2;
+    F.DL(2*j) = F.DL(2*j) - w/2;
+end
+
+%% Live + pedestrian load on bottom chord
+wLive = (9.34e3 + 91.5e3);           % N/m
+F.LIVE = addUniform(F.LIVE, nodes, bottomNodes, [0; -wLive]);
+
+%% Wind load: horizontal pressure distributed to all nodes
+qWind = 3.2e3 * 9.14;                % N/m along span
+F.WIND = addUniform(F.WIND, nodes, bottomNodes, [ qWind/2; 0]);
+F.WIND = addUniform(F.WIND, nodes, 14:26,      [ qWind/2; 0]);
+
+%% Earthquake load: base shear proportional to height
+spanWeight = -sum(F.DL(2:2:end));    % total vertical weight (positive)
+V = 0.16 * spanWeight;               % base shear
+H = 9.14;                            % structure height
+fac = nodes(:,2) / H;                % linear with height
+normFactor = sum(fac);
+for k = 1:n
+    Fx = V * fac(k) / normFactor;
+    F.EQ(2*k-1) = F.EQ(2*k-1) + Fx;
+end
+end
+
+function F = addUniform(F, nodes, seq, w)
+%ADDUNIFORM Distribute a uniform line load to node forces.
+%   F = ADDUNIFORM(F,NODES,SEQ,W) adds the effect of a uniform load per
+%   unit length W = [Wx; Wy] acting along the ordered node sequence SEQ.
+%   Each element between successive nodes receives W*L, half to each end.
+
+for m = 1:numel(seq)-1
+    i = seq(m); j = seq(m+1);
+    L = hypot(nodes(j,1)-nodes(i,1), nodes(j,2)-nodes(i,2));
+    F(2*i-1:2*i) = F(2*i-1:2*i) + w * L/2;
+    F(2*j-1:2*j) = F(2*j-1:2*j) + w * L/2;
+end
+end

--- a/solveServiceLoop.m
+++ b/solveServiceLoop.m
@@ -1,0 +1,47 @@
+function [A_TOP_req, delta_service, U_service, elems] = solveServiceLoop(nodes, elems, Kbuilder, F, span)
+%SOLVESERVICELOOP Iteratively size top chord area for service deflection.
+%   [A_TOP_REQ, DELTA_SERVICE, U_SERVICE, ELEMS] = SOLVESERVICELOOP(NODES,
+%   ELEMS, KBUILDER, F, SPAN) adjusts the top-chord area until the
+%   service-load mid-span deflection limit is met.  KBUILDER is a function
+%   handle returning the global stiffness matrix for the provided nodes and
+%   elements.  F is a struct with load vectors from MAKELOADS.  SPAN
+%   defaults to 73.15 m.
+
+if nargin < 5
+    span = 73.15;
+end
+
+fixedDOF = [1 2 27];
+limit = span / 800;      % service deflection limit (m)
+A_TOP = 0.08;            % initial top-chord area (m^2)
+
+for iter = 1:10
+    % update element areas for top chord
+    for k = 1:numel(elems)
+        if strcmp(elems(k).type, 'TOP')
+            elems(k).A = A_TOP;
+        end
+    end
+
+    K = Kbuilder(nodes, elems);
+    F_srv = F.DL + F.LIVE;
+
+    nd = 2 * size(nodes,1);
+    U = zeros(nd,1);
+    free = setdiff(1:nd, fixedDOF);
+    U(free) = K(free,free) \ F_srv(free);
+
+    delta = U(2*13);  % mid-span bottom-node vertical displacement
+    if abs(delta) <= limit
+        break
+    end
+    A_TOP = A_TOP * 1.2;
+end
+
+A_TOP_req    = A_TOP;
+delta_service = delta;
+U_service     = U;
+
+fprintf('Service: A_TOP=%.3f m^2, \x03b4=%.1f mm (limit 91 mm)\n', ...
+        A_TOP_req, delta_service*1000);
+end

--- a/test_hawthorne_truss.m
+++ b/test_hawthorne_truss.m
@@ -12,3 +12,6 @@ end
 K = assembleK(nodes, elems, E);
 fprintf('size(K) = %dx%d\n', size(K,1), size(K,2));
 fprintf('rank(full(K)) = %d\n', rank(full(K)));
+
+F = makeLoads(nodes, elems);
+fprintf('size(F.DL) = %dx1\n', numel(F.DL));

--- a/test_hawthorne_truss.m
+++ b/test_hawthorne_truss.m
@@ -8,3 +8,7 @@ for k = 1:5
     e = elems(k);
     fprintf('%d %d %s A=%.2f\n', e.i, e.j, e.type, e.A);
 end
+
+K = assembleK(nodes, elems, E);
+fprintf('size(K) = %dx%d\n', size(K,1), size(K,2));
+fprintf('rank(full(K)) = %d\n', rank(full(K)));

--- a/test_hawthorne_truss.m
+++ b/test_hawthorne_truss.m
@@ -15,3 +15,6 @@ fprintf('rank(full(K)) = %d\n', rank(full(K)));
 
 F = makeLoads(nodes, elems);
 fprintf('size(F.DL) = %dx1\n', numel(F.DL));
+
+Kbuilder = @(n,e) assembleK(n,e,E);
+[reqA, delta_srv, U_srv, elems] = solveServiceLoop(nodes, elems, Kbuilder, F);

--- a/test_hawthorne_truss.m
+++ b/test_hawthorne_truss.m
@@ -1,0 +1,10 @@
+[nodes, elems, A, E, fy] = hawthorne_truss();
+
+fprintf('First 5 nodes:\n');
+disp(nodes(1:5,:));
+
+fprintf('First 5 elements:\n');
+for k = 1:5
+    e = elems(k);
+    fprintf('%d %d %s A=%.2f\n', e.i, e.j, e.type, e.A);
+end

--- a/trussKe.m
+++ b/trussKe.m
@@ -1,0 +1,19 @@
+function k = trussKe(xi,yi,xj,yj,E,A)
+%TRUSSKE 4x4 local stiffness for a 2D truss element.
+%   k = TRUSSKE(xi,yi,xj,yj,E,A) returns the local axial stiffness matrix
+%   for a bar from node i (xi,yi) to node j (xj,yj) with Young's modulus E
+%   and cross-sectional area A. The matrix is in global coordinates using
+%   2 DOF per node.
+
+L = hypot(xj - xi, yj - yi);
+c = (xj - xi) / L;
+s = (yj - yi) / L;
+
+k_local = E*A/L * ...
+    [ c*c,  c*s, -c*c, -c*s;...
+      c*s,  s*s, -c*s, -s*s;...
+     -c*c, -c*s,  c*c,  c*s;...
+     -c*s, -s*s,  c*s,  s*s ];
+
+k = k_local;
+end


### PR DESCRIPTION
## Summary
- expand `hawthorne_truss` to include material properties and section areas
- print element areas in `test_hawthorne_truss`

## Testing
- `matlab -batch "test_hawthorne_truss"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a6bcf2e9483319101e2924974284e